### PR TITLE
[#8] Fix treatment assignment bug in DGP function

### DIFF
--- a/dgp_function.R
+++ b/dgp_function.R
@@ -34,8 +34,7 @@ genData <- function(numObs, treatRatio, trueTau) {
   
   W <- rep(0, times = n)
   
-  n1 <- (a / (1+a)) * n
-  n0 <- (1 / (1+a)) * n
+  n1 <- round((a / (1+a)) * n)
   
     # Create sequence of indices to sample from
     indices <- seq(from = 1, to = n, by = 1)


### PR DESCRIPTION
The `genData` function uses `sample` when it assigns treatment to
the units, but the number of observations receiving treatment is
not stored as an integer variable. Since `sample` uses `as.integer`
to convert noninteger arguments to integers, and `as.integer`
truncates the noninteger component of numbers it converts, this
combination sometimes resulted in one too few treatment units.

This commit adds one step: explicitly rounding the number of
tretment units to the nearest integer before passing it as an
argument to sample, fixing the bug.